### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,10 @@ allprojects {
 	repositories {
 		//mavenLocal()
 		mavenCentral()
-		maven { url "http://repo.springsource.org/snapshot" }
-		maven { url "http://repo.springsource.org/release" }
-		maven { url "http://repo.springsource.org/milestone" }
-		maven { url "http://mvnrepository.com/artifact" }
+		maven { url "https://repo.springsource.org/snapshot" }
+		maven { url "https://repo.springsource.org/release" }
+		maven { url "https://repo.springsource.org/milestone" }
+		maven { url "https://mvnrepository.com/artifact" }
 	}
 
 	dependencies {

--- a/samples/wordcount-batch-notification/build.gradle
+++ b/samples/wordcount-batch-notification/build.gradle
@@ -11,13 +11,13 @@ repositories {
     mavenCentral()
     // Public Spring artefacts
     maven{ 
-		url "http://repo.springsource.org/release"
-		url "http://repo.springsource.org/milestone"
-		url "http://repo.springsource.org/snapshot"
-		url "http://oss.sonatype.org/content/repositories/snapshots"
-		url "http://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/"
+		url "https://repo.springsource.org/release"
+		url "https://repo.springsource.org/milestone"
+		url "https://repo.springsource.org/snapshot"
+		url "https://oss.sonatype.org/content/repositories/snapshots"
+		url "https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/"
 		url "http://www.datanucleus.org/downloads/maven2/"
-		url "http://conjars.org/repo"
+		url "https://conjars.org/repo"
     }
 }
 

--- a/templates/Cascading/pom.xml
+++ b/templates/Cascading/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>

--- a/templates/HBase/pom.xml
+++ b/templates/HBase/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>

--- a/templates/HDFS/pom.xml
+++ b/templates/HDFS/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>

--- a/templates/Hive/pom.xml
+++ b/templates/Hive/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>

--- a/templates/MapReduce/pom.xml
+++ b/templates/MapReduce/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>

--- a/templates/Pig/pom.xml
+++ b/templates/Pig/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>wordcount</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<hadoop.version>1.0.0</hadoop.version>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.datanucleus.org/downloads/maven2/ (200) migrated to:  
  http://www.datanucleus.org/downloads/maven2/ ([https](https://www.datanucleus.org/downloads/maven2/) result AnnotatedConnectException).
* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/ (404) migrated to:  
  https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/ ([https](https://springframework.svn.sourceforge.net/svnroot/springframework/repos/repo-ext/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://maven.apache.org migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://conjars.org/repo migrated to:  
  https://conjars.org/repo ([https](https://conjars.org/repo) result 301).
* http://repo.springsource.org/milestone migrated to:  
  https://repo.springsource.org/milestone ([https](https://repo.springsource.org/milestone) result 301).
* http://repo.springsource.org/release migrated to:  
  https://repo.springsource.org/release ([https](https://repo.springsource.org/release) result 301).
* http://repo.springsource.org/snapshot migrated to:  
  https://repo.springsource.org/snapshot ([https](https://repo.springsource.org/snapshot) result 301).
* http://oss.sonatype.org/content/repositories/snapshots migrated to:  
  https://oss.sonatype.org/content/repositories/snapshots ([https](https://oss.sonatype.org/content/repositories/snapshots) result 302).
* http://mvnrepository.com/artifact migrated to:  
  https://mvnrepository.com/artifact ([https](https://mvnrepository.com/artifact) result 303).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance