### PR TITLE
URL Cleanup

### DIFF
--- a/CLI/common/src/main/java/org/springframework/data/hadoop/admin/cli/util/Log.java
+++ b/CLI/common/src/main/java/org/springframework/data/hadoop/admin/cli/util/Log.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/common/src/main/java/org/springframework/data/hadoop/admin/cli/util/PropertyUtil.java
+++ b/CLI/common/src/main/java/org/springframework/data/hadoop/admin/cli/util/PropertyUtil.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/common/src/test/java/org/springframework/data/hadoop/admin/cli/util/PropertyUtilTest.java
+++ b/CLI/common/src/test/java/org/springframework/data/hadoop/admin/cli/util/PropertyUtilTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/BaseCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/BaseCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ExecutionsCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ExecutionsCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/InfoCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/InfoCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/JobsCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/JobsCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ProjectCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ProjectCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ProjectType.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/ProjectType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/TargetCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/TargetCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/TemplateCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/TemplateCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/WorkflowCommand.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/commands/WorkflowCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminBannerProvider.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminBannerProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminHistoryFileNameProvider.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminHistoryFileNameProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminPromptProvider.java
+++ b/CLI/plugin-admin/src/main/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminPromptProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/BaseCommandTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/BaseCommandTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/FileCommandTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/FileCommandTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/ProjectCommandTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/commands/ProjectCommandTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminBannerProviderTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminBannerProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminHistoryFileNameProviderTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminHistoryFileNameProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminPromptProviderTest.java
+++ b/CLI/plugin-admin/src/test/java/org/springframework/data/hadoop/admin/cli/plugin/SpringHadoopAdminPromptProviderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/wordcount-batch-notification/src/main/java/org/springframework/data/hadoop/admin/examples/EmailNotification.java
+++ b/samples/wordcount-batch-notification/src/main/java/org/springframework/data/hadoop/admin/examples/EmailNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/wordcount-batch-notification/src/test/java/org/springframework/data/hadoop/admin/examples/EmailNotificationTest.java
+++ b/samples/wordcount-batch-notification/src/test/java/org/springframework/data/hadoop/admin/examples/EmailNotificationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/SpringHadoopAdminException.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/SpringHadoopAdminException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/BaseWorkflowEntity.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/BaseWorkflowEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/MessageEntity.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/MessageEntity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkerNode.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkerNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkflowExecution.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkflowExecution.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkflowLaunchRequest.java
+++ b/scalable-service/common/src/main/java/org/springframework/data/hadoop/admin/entity/WorkflowLaunchRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/SpringHadoopAdminWorkflowException.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/SpringHadoopAdminWorkflowException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/message/MessageProducer.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/message/MessageProducer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/BaseFileService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/BaseFileService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileInfo.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileRemover.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileRemover.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileSender.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/FileService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/SimpleTemplateService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/SimpleTemplateService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/SimpleWorkflowService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/SimpleWorkflowService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/TemplateInfo.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/TemplateInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/TemplateService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/TemplateService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/WorkflowInfo.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/WorkflowInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/WorkflowService.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/service/WorkflowService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/Constant.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/Constant.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowDescriptorUtils.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowDescriptorUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowUtils.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/TemplateController.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/TemplateController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/TemplateMenu.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/TemplateMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/WorkflowController.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/WorkflowController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/WorkflowMenu.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/web/WorkflowMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectory.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryFilter.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowLaunchRequestAdapter.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowLaunchRequestAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowRemoveRequestAdapter.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowRemoveRequestAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/SimpleSpringHadoopTasklet.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/SimpleSpringHadoopTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextFactory.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextsFactoryBean.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextsFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemWorkflowResourceFactoryBean.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemWorkflowResourceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/WorkflowArtifacts.java
+++ b/scalable-service/master/src/main/java/org/springframework/data/hadoop/admin/workflow/support/WorkflowArtifacts.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/message/MessageProducerTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/message/MessageProducerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowDescriptorUtilsTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowDescriptorUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowUtilsTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/HadoopWorkflowUtilsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/SimpleBean.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/util/SimpleBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryFilterTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryFilterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowDirectoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowLaunchRequestAdapterTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowLaunchRequestAdapterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowRemoveRequestAdapterTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/HadoopWorkflowRemoveRequestAdapterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/SimpleSpringHadoopTaskletTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/SimpleSpringHadoopTaskletTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextFactoryTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextFactoryTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextsFactoryBeanTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemApplicationContextsFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemWorkflowResourceFactoryBeanTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/FileSystemWorkflowResourceFactoryBeanTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/WorkflowArtifactsTest.java
+++ b/scalable-service/master/src/test/java/org/springframework/data/hadoop/admin/workflow/support/WorkflowArtifactsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/WorkerNode.java
+++ b/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/WorkerNode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/WorkflowLaunchException.java
+++ b/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/WorkflowLaunchException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/launch/LaunchWorkflow.java
+++ b/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/launch/LaunchWorkflow.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/launch/support/LaunchWorkflowInProcess.java
+++ b/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/launch/support/LaunchWorkflowInProcess.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/message/MessageConsumer.java
+++ b/scalable-service/slave/src/main/java/org/springframework/data/hadoop/admin/message/MessageConsumer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 76 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).